### PR TITLE
improve disk dialog, show only disk ID without path

### DIFF
--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -111,7 +111,7 @@ get_disk() {
         if [ -n "${disk_device_by_id}" ];then
             disk_device=${disk_device_by_id}
         fi
-        list_items="${list_items} ${disk_device} ${disk_size}"
+        list_items="${list_items} $(basename ${disk_device}) ${disk_size}"
     done
     if [ -n "${TIK_INSTALL_DEVICE}" ];then
         # install device overwritten by config.
@@ -131,7 +131,7 @@ get_disk() {
             grep -E "disk|raid" | tr ' ' ":"
         )
         device_size=$(echo "${device_meta}" | cut -f2 -d:)
-        list_items="${device} ${device_size}"
+        list_items="$(basename ${device}) ${device_size}"
         message="tik installation device set to to: ${device}"
         log "${message}"
     fi
@@ -152,11 +152,13 @@ get_disk() {
         done
         if [ "${device_index}" -eq 1 ];then
             # one single disk device found, use it
-            TIK_INSTALL_DEVICE="${device_array[0]}"
+            # Add back full path to it
+            TIK_INSTALL_DEVICE="/dev/disk/by-id/${device_array[0]}"
         else
             # manually select from storage list
             d --list --column=Disk --column=Size --width=1000 --height=340 --title="Select A Disk" --text="Select the disk to install the operating system to. <b>Make sure any important documents and files have been backed up.</b>\n" ${list_items}
-            TIK_INSTALL_DEVICE="$result"
+            # Add back full path to it
+            TIK_INSTALL_DEVICE="/dev/disk/by-id/$result"
         fi
     fi
 }


### PR DESCRIPTION
Small improvement

We remove the /dev/disk/by-id from the list or results so that the zenity popup is cleared
and we add it back to the result

![Screenshot from 2024-05-02 18-30-03](https://github.com/sysrich/tik/assets/598882/a7374ac2-de4d-453d-b7c5-551fc3dd0d92)
![Screenshot from 2024-05-02 18-30-14](https://github.com/sysrich/tik/assets/598882/8fb18c96-9020-4020-87ae-baf21e3b65ff)
