### PR TITLE
Added code to detect laptop is connected to AC power before proceeding to copy home files to flash drive and starting upgrade

### DIFF
--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -1,5 +1,39 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright 2024 SUSE LLC
-# SPDX-FileCopyrightText: Copyright 2024 Richard Brown
+# SPDX-FileCopyrightText: Copyright 2024 Raymond Yip
 
-d --info --ok-label="Install Now" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="<big>Welcome to ${TIK_OS_NAME}</big>\n\nPlease press <b>Install Now</b> to continue"
+proceedInstall() {
+	d --info --ok-label="Install Now" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="<big>Welcome to ${TIK_OS_NAME}</big>\n\nPlease press <b>Install Now</b> to continue"
+}
+
+warningMSG() {
+	d --warning --ok-label="OK" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="Please connect the AC power adapter to your machine to continue" 
+}
+
+checkLaptop() {
+	chassis=`cat /sys/class/dmi/id/chassis_type`
+	#Test for respectively Handheld, Notebook, Laptop, and Portable
+	if [ $chassis = "11" ] || [ $chassis = "10" ] || [ $chassis = "9" ] || [ $chassis = "8" ]; then
+		#Tested machine is confirmed mobile
+		#Check for AC power connection
+		#Check file exists first
+		if [ -f "/sys/class/power_supply/AC/online" ]; then
+			#File exists
+			#While the AC power cable is still disconnected
+			while (grep -Fxq "0" "/sys/class/power_supply/AC/online"); then
+				echo "AC power disconnected"
+				#Display warning message
+				warningMSG()
+				sleep 1
+			done
+		fi
+		proceedInstall
+	else
+		#Tested machine is a desktop
+		proceedInstall
+	fi
+}
+
+checkLaptop
+
+

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -27,13 +27,10 @@ checkLaptop() {
 				warningMSG
 			done
 		fi
-		proceedInstall
-	else
-		#Tested machine is a desktop
-		proceedInstall
 	fi
 }
 
+proceedInstall
 checkLaptop
 
 

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright 2024 SUSE LLC
-# SPDX-FileCopyrightText: Copyright 2024 Raymond Yip
+# SPDX-FileCopyrightText: Copyright 2024 Richard Brown
+# File Author: Raymond Yip
 
 proceedInstall() {
 	d --info --ok-label="Install Now" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="<big>Welcome to ${TIK_OS_NAME}</big>\n\nPlease press <b>Install Now</b> to continue"

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -8,7 +8,7 @@ proceedInstall() {
 }
 
 warningMSG() {
-	d --warning --ok-label="OK" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="Please connect the AC power adapter to your machine to continue" 
+	d --warning --no-wrap --title="AC Power Required" --text="Please connect the AC power adapter to your machine to continue" 
 }
 
 checkLaptop() {
@@ -21,11 +21,10 @@ checkLaptop() {
 		if [ -f "/sys/class/power_supply/AC/online" ]; then
 			#File exists
 			#While the AC power cable is still disconnected
-			while (grep -Fxq "0" "/sys/class/power_supply/AC/online"); then
+			while (grep -Fxq "0" "/sys/class/power_supply/AC/online"); do
 				echo "AC power disconnected"
 				#Display warning message
-				warningMSG()
-				sleep 1
+				warningMSG
 			done
 		fi
 		proceedInstall


### PR DESCRIPTION
My first contribution to OpenSUSE Aeon, it may not be perfect, edit as you wish. This code makes sure that the laptop that is being upgraded is plugged into AC power. 