### PR TITLE
Set boot target after all modules

### DIFF
--- a/usr/bin/tik
+++ b/usr/bin/tik
@@ -55,9 +55,9 @@ load_modules "pre" "custom"
 get_disk
 get_img
 dump_image "${TIK_INSTALL_IMAGE}" "${TIK_INSTALL_DEVICE}"
-set_boot_target
 
 load_modules "post"
 load_modules "post" "custom"
 
+set_boot_target
 


### PR DESCRIPTION
To make weird UEFI firmwares less problematic, if stuff goes wrong people will at least have stuff like backups restored already