### PR TITLE
module-mig: make /etc umount optional - doesn't mount on Leap/TW sources

### DIFF
--- a/usr/lib/tik/modules/pre/20-mig
+++ b/usr/lib/tik/modules/pre/20-mig
@@ -175,7 +175,7 @@ if [ -z "${skipbackup}" ]; then
       	prun-opt /usr/bin/cp -a ${mig_dir}/mnt/var/lib/AccountsService/users ${mig_dir}/users
       	prun-opt /usr/bin/chmod 744 ${mig_dir}/users
       	prun-opt /usr/bin/cp -a ${mig_dir}/mnt/var/lib/AccountsService/icons ${mig_dir}/icons
-      	prun /usr/bin/umount ${mig_dir}/mnt/etc
+      	prun-opt /usr/bin/umount ${mig_dir}/mnt/etc
       	prun /usr/bin/umount ${mig_dir}/mnt/var
       	prun /usr/bin/umount ${mig_dir}/mnt
       	prun /usr/bin/rmdir ${mig_dir}/mnt


### PR DESCRIPTION
oops, looks like we accidentally built migration tooling for TW/Leap to Aeon, so might as well support it