### PR TITLE
Filters USB devices to not be listed in disk selection dialog. Add a config value to allow USB devices to show in selection dialog. Fixes installation on USB devices.

### DIFF
--- a/usr/lib/tik/config
+++ b/usr/lib/tik/config
@@ -6,6 +6,10 @@ TIK_CUSTOM_DIR="/etc/tik"
 # Default: "/usr/lib/tik/img"
 TIK_IMG_DIR="/usr/lib/tik/img"
 
+# To show USB devices in the install device selection dialog, uncomment this variable
+# USB devices are filtered out by default
+#TIK_ALLOW_USB_INSTALL_DEVICES=1
+
 # For unattended installations the disk device to deploy the image must be defined
 # Default: Undefined
 #TIK_INSTALL_DEVICE=""

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -89,6 +89,13 @@ get_disk() {
     local message
     local blk_opts_plus_label="${blk_opts},LABEL"
     local tik_install_disk_part
+    local part_meta
+    local part_count
+    local part_size
+    local part_info
+    local part_label
+    local part_fs
+    local blk_opts_part_info="${blk_opts_plus_label},FSTYPE"
 
     tik_install_disk_part=$(
         eval lsblk "${blk_opts_plus_label}" | \
@@ -106,6 +113,28 @@ get_disk() {
             continue
         fi
         disk_device="$(echo "${disk_meta}" | cut -f1 -d:)"
+        # find partitions and info for this disk
+        part_count=0
+        part_info=""
+        for part_meta in $(
+            eval lsblk "${blk_opts_part_info}" | grep -E "${disk_device}.+part.+" | tr ' ' ":"
+        );do
+            part_count=$(expr $part_count + 1)
+            part_size=$(echo "${part_meta}" | cut -f2 -d:)
+            part_label=$(echo "${part_meta}" | cut -f4 -d:)
+            part_fs=$(echo "${part_meta}" | cut -f5 -d:)
+            if [ -n "${part_info}" ]; then
+                part_info="${part_info};"
+            fi
+            if [ -n "${part_label}" ]; then
+                part_info="${part_info}${part_label}"
+            fi
+            if [ -n "${part_fs}" ]; then
+                part_info="${part_info}(${part_fs},${part_size})"
+            else
+                part_info="${part_info}(${part_size})"
+            fi
+        done
         if [[ "${tik_install_disk_part}" == "${disk_device}"* ]]; then
             # ignore install source device
             continue
@@ -124,7 +153,8 @@ get_disk() {
         if [ -n "${disk_device_by_id}" ];then
             disk_device=${disk_device_by_id}
         fi
-        list_items="${list_items} $(basename ${disk_device}) ${disk_size}"
+        list_items="${list_items} $(basename ${disk_device}) ${disk_size} ${part_count} ${part_info}"
+        disk_list="${disk_list} $(basename ${disk_device}) ${disk_size}"
     done
     if [ -n "${TIK_INSTALL_DEVICE}" ];then
         # install device overwritten by config.
@@ -144,7 +174,9 @@ get_disk() {
             grep -E "disk|raid" | tr ' ' ":"
         )
         device_size=$(echo "${device_meta}" | cut -f2 -d:)
+        # this case is not shown in manual selection, threfore we don't need partition info        
         list_items="$(basename ${device}) ${device_size}"
+        disk_list="$(basename ${device}) ${device_size}"
         message="tik installation device set to to: ${device}"
         log "${message}"
     fi
@@ -152,7 +184,6 @@ get_disk() {
         local no_device_text="No device(s) for installation found."
         error "${no_device_text}"
     fi
-    disk_list=${list_items}
     if [ -n "${disk_list}" ];then
         local count=0
         local device_index=0
@@ -175,7 +206,7 @@ get_disk() {
             fi
         else
             # manually select from storage list
-            d --list --column=Disk --column=Size --width=1000 --height=340 --title="Select A Disk" --text="Select the disk to install the operating system to. <b>Make sure any important documents and files have been backed up.</b>\n" ${list_items}
+            d --list --column=Disk --column=Size --column=Partitions --column=Partition-info --width=1000 --height=340 --title="Select A Disk" --text="Select the disk to install the operating system to. <b>Make sure any important documents and files have been backed up.</b>\n" ${list_items}
             # Add back full path to it
             TIK_INSTALL_DEVICE="/dev/disk/${disk_id}/${result}"
 
@@ -201,9 +232,9 @@ get_img() {
     for img_meta in $(
         eval cd $TIK_IMG_DIR && (stat --printf="%n\t%s\n" *.raw.xz | tr '	' ":")
     );do
-         img_filename="$(echo $img_meta | cut -f1 -d:)"
-         img_size="$(echo $img_meta | cut -f2 -d:)"
-         list_items="${list_items} ${img_filename} ${img_size}"
+        img_filename="$(echo $img_meta | cut -f1 -d:)"
+        img_size="$(echo $img_meta | cut -f2 -d:)"
+        list_items="${list_items} ${img_filename} ${img_size}"
     done
     if [ -n "${TIK_INSTALL_IMAGE}" ];then
         # install image overwritten by config.

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -124,15 +124,15 @@ get_disk() {
             part_label=$(echo "${part_meta}" | cut -f4 -d:)
             part_fs=$(echo "${part_meta}" | cut -f5 -d:)
             if [ -n "${part_info}" ]; then
-                part_info="${part_info};"
+                part_info="${part_info},"
             fi
-            if [ -n "${part_label}" ]; then
-                part_info="${part_info}${part_label}"
-            fi
+#            if [ -n "${part_label}" ]; then
+#                part_info="${part_info}${part_label}"
+#            fi
             if [ -n "${part_fs}" ]; then
-                part_info="${part_info}(${part_fs},${part_size})"
+                part_info="${part_info}${part_fs}(${part_size})"
             else
-                part_info="${part_info}(${part_size})"
+                part_info="${part_info}unknown(${part_size})"
             fi
         done
         if [[ "${tik_install_disk_part}" == "${disk_device}"* ]]; then
@@ -206,7 +206,7 @@ get_disk() {
             fi
         else
             # manually select from storage list
-            d --list --column=Disk --column=Size --column=Partitions --column=Partition-info --width=1000 --height=340 --title="Select A Disk" --text="Select the disk to install the operating system to. <b>Make sure any important documents and files have been backed up.</b>\n" ${list_items}
+            d --list --column=Disk --column=Size --column=Partitions --column=Filesystems --width=1000 --height=340 --title="Select A Disk" --text="Select the disk to install the operating system to. <b>Make sure any important documents and files have been backed up.</b>\n" ${list_items}
             # Add back full path to it
             TIK_INSTALL_DEVICE="/dev/disk/${disk_id}/${result}"
 

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -132,6 +132,9 @@ get_disk() {
                 part_info="${part_info}unknown(${part_size})"
             fi
         done
+        if [[ ${part_count} -eq 0 ]]; then
+            part_info="none"
+        fi
         if [[ "${tik_install_disk_part}" == "${disk_device}"* ]]; then
             # ignore install source device
             continue

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -95,6 +95,8 @@ get_disk() {
     local part_info
     local part_fs
     local blk_opts_part_info="${blk_opts_plus_label},FSTYPE"
+    local usb_match_1="usb"
+    local usb_match_2=":0"
 
     tik_install_disk_part=$(
         eval lsblk "${blk_opts_plus_label}" | \
@@ -145,6 +147,10 @@ get_disk() {
         disk_device_by_id=$(
             get_persistent_device_from_unix_node "${disk_device}" "${disk_id}"
         )
+        if [[ ( "${TIK_ALLOW_USB_INSTALL_DEVICES}" -ne 1 ) && ( "{$disk_device_by_id}" == *"${usb_match_1}"* || "{$disk_device_by_id}" == *"${usb_match_2}"* ) ]]; then
+            # ignore USB devices if TIK_ALLOW_USB_INSTALL_DEVICES not set in config
+            continue
+        fi
         if [ -n "${disk_device_by_id}" ];then
             disk_device=${disk_device_by_id}
         fi

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -93,7 +93,6 @@ get_disk() {
     local part_count
     local part_size
     local part_info
-    local part_label
     local part_fs
     local blk_opts_part_info="${blk_opts_plus_label},FSTYPE"
 
@@ -121,14 +120,10 @@ get_disk() {
         );do
             part_count=$(expr $part_count + 1)
             part_size=$(echo "${part_meta}" | cut -f2 -d:)
-            part_label=$(echo "${part_meta}" | cut -f4 -d:)
             part_fs=$(echo "${part_meta}" | cut -f5 -d:)
             if [ -n "${part_info}" ]; then
                 part_info="${part_info},"
             fi
-#            if [ -n "${part_label}" ]; then
-#                part_info="${part_info}${part_label}"
-#            fi
             if [ -n "${part_fs}" ]; then
                 part_info="${part_info}${part_fs}(${part_size})"
             else

--- a/usr/lib/tik/modules/pre/20-mig
+++ b/usr/lib/tik/modules/pre/20-mig
@@ -20,11 +20,13 @@ probe_partitions() {
 	fi
 	prun /usr/bin/mkdir -p ${mig_dir}/mnt
 	probedpart=""
-	for part in $(lsblk ${device} -p -n -r -o ID-LINK,FSTYPE|tr -s ' ' ":"|grep ":${filesystem_type}"|cut -d: -f1); do
-	    prun /usr/bin/mount ${mountops} /dev/disk/by-id/${part} ${mig_dir}/mnt
+	for part in $(lsblk ${device} -p -n -r -o ID-LINK,FSTYPE|tr -s ' ' ";"|grep ";${filesystem_type}"|cut -d\; -f1); do
+		# Fallback to unix device in order to fix issue with USB devices
+	    prun /usr/bin/mount ${mountops} "$(/usr/bin/readlink -f "/dev/disk/by-id/${part}")" "${mig_dir}/mnt"
 	    # Check if ${filematch} exists
 	    if [ -f ${mig_dir}/mnt/${filematch} ]; then
-	        probedpart=/dev/disk/by-id/${part}
+			# Fallback to unix device in order to fix issue USB devices
+	        probedpart="$(/usr/bin/readlink -f "/dev/disk/by-id/""${part}")"
 	        log "[probe_partitions] /dev/disk/by-id/${part} found"
 	        if grep -q 'PRETTY_NAME="openSUSE MicroOS"' ${mig_dir}/mnt/${filematch} && [ -f ${mig_dir}/mnt/usr/bin/gnome-shell ]; then
         		# Found legacy Aeon, activate easter egg
@@ -76,7 +78,7 @@ if [ -z "${skipbackup}" ]; then
   # some users might have nevertheless enabled encryption anyway.
   # Search for existing crypto_LUKS partitions and, if found, prompt the user
   # to unlock those so that the migration module can find existing data.
-  for encrypted_partition in $(lsblk ${TIK_INSTALL_DEVICE} -p -n -r -o ID-LINK,FSTYPE|tr -s ' ' ":"|grep ":crypto_LUKS"|cut -d: -f1); do
+  for encrypted_partition in $(lsblk ${TIK_INSTALL_DEVICE} -p -n -r -o ID-LINK,FSTYPE|tr -s ' ' ";"|grep ";crypto_LUKS"|cut -d\; -f1); do
       if [ -e /dev/mapper/crypt_${encrypted_partition} ]; then
           # Already opened for some reason... do not prompt for the passphrase
           # but ensure we will clean up afterwards


### PR DESCRIPTION
This PR fixes the installation on USB devices:
- USB devices are filtered out by default and not offered as installation devices
- A new config value allows optionally to disable the USB filter, show USB devices in the selection dialog and allow the installation
- A change in the mig module fixes the issue with failed installations on USB devices