### PR TITLE
Fix/1225633_verify-efi

### DIFF
--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -30,7 +30,17 @@ checkLaptop() {
 	fi
 }
 
+verify_efi() {
+	# Verify that the system was booted with EFI, exit with error if not
+	if [ ! -d /sys/firmware/efi ]; then
+		# System was not booted with EFI
+		local error_msg="Aeon requires EFI mode.\nEFI is not present on this system. You might check if EFI can be enabled in the BIOS settings."
+		error "${error_msg}"
+	fi
+}
+
 proceedInstall
+verify_efi
 checkLaptop
 
 

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -34,7 +34,7 @@ verify_efi() {
 	# Verify that the system was booted with EFI, exit with error if not
 	if [ ! -d /sys/firmware/efi ]; then
 		# System was not booted with EFI
-		local error_msg="Aeon requires EFI mode.\nEFI is not present on this system. You might check if EFI can be enabled in the BIOS settings."
+		local error_msg="openSUSE Aeon requires EFI mode, which is not found on your system.\nPlease check your BIOS settings to see if EFI can be enabled."
 		error "${error_msg}"
 	fi
 }

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -34,7 +34,7 @@ verify_efi() {
 	# Verify that the system was booted with EFI, exit with error if not
 	if [ ! -d /sys/firmware/efi ]; then
 		# System was not booted with EFI
-		local error_msg="openSUSE Aeon requires EFI mode, which is not found on your system.\nPlease check your BIOS settings to see if EFI can be enabled."
+		local error_msg="openSUSE Aeon requires UEFI mode, which is not found on your system.\nPlease check your BIOS settings to see if UEFI can be enabled."
 		error "${error_msg}"
 	fi
 }


### PR DESCRIPTION
Fixes the bug 1225633. Check if installer has been booted in UEFI mode and throws an error if not.
https://bugzilla.opensuse.org/show_bug.cgi?id=1225633

I tested the fix on an UEFI system only. I used an inverted check ( without the ! in the check) to verify that the error message triggers correctly. I'm pretty sure it works. However, I couldn't test the fix on a BIOS mode system.