### PR TITLE
mig: Don't fail migration if system is not encrypted

### DIFF
--- a/usr/lib/tik/modules/post/20-mig
+++ b/usr/lib/tik/modules/post/20-mig
@@ -19,16 +19,11 @@ EOF
 
 if [ "${migrate}" == 1 ]; then
     probe_partitions ${TIK_INSTALL_DEVICE} "crypto_LUKS"
-    if [ -z "${probedpart}" ]; then
-        error "encrypted partition not found"
-    fi
-    prun /usr/sbin/cryptsetup luksOpen --key-file=${tik_keyfile} ${cryptpart} aeon_root
+    [ -z "${probedpart}" ] || prun /usr/sbin/cryptsetup luksOpen --key-file=${tik_keyfile} ${cryptpart} aeon_root
 
     probe_partitions $TIK_INSTALL_DEVICE "btrfs" "/usr/lib/os-release"
 
-    if [ -z "${probedpart}" ]; then
-        error "MIGRATION FAILED: New Installation NOT FOUND"
-    fi
+    [ -n "${probedpart}" ] || error "MIGRATION FAILED: New Installation NOT FOUND"
 
     prun /usr/bin/mkdir ${mig_dir}/mnt
     prun /usr/bin/mount -o compress=zstd:1 ${probedpart} ${mig_dir}/mnt
@@ -71,5 +66,5 @@ if [ "${migrate}" == 1 ]; then
     done
     prun /usr/bin/umount ${mig_dir}/mnt
     prun /usr/bin/rmdir ${mig_dir}/mnt
-    prun /usr/sbin/cryptsetup luksClose aeon_root
+    [ ! -e /dev/mapper/aeon_root ] || prun /usr/sbin/cryptsetup luksClose aeon_root
 fi


### PR DESCRIPTION
The current migration module fails if the installed system is not encrypted. However, the migration logic isn't bound to the system being encrypted.
This PR makes the encryption optional, rather than mandatory. The migration will work on both encrypted and unencrypted systems.

This is useful as I do not want Yuga Linux to be encrypted, but the migration feature is still useful.