### PR TITLE
fix(fallback): ask the user passphase twice, to be sure no accidental typos are in input

### DIFF
--- a/usr/lib/tik/modules/pre/20-mig
+++ b/usr/lib/tik/modules/pre/20-mig
@@ -58,6 +58,13 @@ if [ -z "${skipbackup}" ]; then
             else
                 while [ 1 ]; do
                     passphrase=$(zenity --password --title="Encrypted partition (${encrypted_partition}) detected" --cancel-label="Skip") || break
+                    # Ask again, and double check the user is putting the right passphrase again.
+                    passphrase_check=$(zenity --password --title="Type passphrase again" --cancel-label="Skip") || break
+                    if [ "$passphrase" != "$passphrase_check" ]; then
+                        d --warning --no-wrap --title="Passphrase did not match" --text="Passphrase did not match, try again"
+                        # Reset variable, so we can try again
+                        passphrase=""
+                    fi
                     if [ -n "${passphrase}" ]; then
                         echo -n "${passphrase}" | prun /usr/sbin/cryptsetup luksOpen /dev/disk/by-id/${encrypted_partition} crypt_${encrypted_partition}
                         if [ "${?}" -eq 0 ]; then


### PR DESCRIPTION
On an old system I was bit by this :sweat_smile: 
Just a simple double check in order to not resort to the recovery key just for a typo