### PR TITLE
Fix issue 47 - cenity: cancelling does not work

### DIFF
--- a/usr/lib/tik/lib/cenity
+++ b/usr/lib/tik/lib/cenity
@@ -9,6 +9,7 @@ cenity() {
   cancel=true
   autoclose=false
   pulsate=false
+  ctrlc=false
   retvalue=0
   columns=()
   content=()
@@ -81,9 +82,9 @@ cenity() {
     if ! $cancel; then
       echo "No Cancel"
     else
-      echo "Cancelled"
-      retvalue=1
-      return $retvalue
+      echo "Cancelled, press Enter to continue"
+      ctrlc=true
+      return 1
     fi
   }
 
@@ -119,6 +120,11 @@ cenity() {
   fi
 
   eval $1='$result'
+
+  if $ctrlc; then
+    retvalue=1
+  fi
+
   return $retvalue
 }
 

--- a/usr/lib/tik/lib/cenity
+++ b/usr/lib/tik/lib/cenity
@@ -239,8 +239,8 @@ c_list() {
   echo -e "\nPlease select a item number"
   read
 
-  retval=$(printf "%s" "${lines[$REPLY]}" | cut -d $'\t' -f1)
-  eval $1='$retval'
+  local selected=$(printf "%s" "${lines[$REPLY]}" | cut -d $'\t' -f1)
+  eval $1='$selected'
 }
 
 

--- a/usr/lib/tik/lib/tik-functions
+++ b/usr/lib/tik/lib/tik-functions
@@ -25,10 +25,11 @@ d(){
         retval=0
         if $gui; then
             result="$(zenity "$@")" || retval=$?
+            log "[zenity][${retval}][${result}] $@"
         else
             cenity result "$@" || retval=$?
+            log "[cenity][${retval}][${result}] $@"
         fi
-        log "[zenity][${retval}][${result}] $@"
         case $retval in
             0)
                 return 0


### PR DESCRIPTION
This change 

- Fixes https://github.com/sysrich/tik/issues/47 (returns 1 when CTRL-C is caught.)
- Fixes the c_list function to not overwrite $retval in tik
- Improves debug output for cenity/zenity