### PR TITLE
Add cenity functionality to handle ok-label and cancel-label

### DIFF
--- a/tests/cenity/d_function_test
+++ b/tests/cenity/d_function_test
@@ -2,7 +2,13 @@ cenity="../../usr/lib/tik/lib/cenity"
 . $cenity
 
 compare() {
-    diff -y <(echo "$1") <(echo "$2") || RESULT=$((RESULT+1))
+    if [ "$mode" = "output" ]; then
+        echo "$1"
+    elif [ "$mode" = "sidebyside" ]; then
+        diff -y <(echo "$1") <(echo "$2") || RESULT=$((RESULT+1))
+    else
+        diff <(echo "$1") <(echo "$2") || RESULT=$((RESULT+1))
+    fi
 }
 
 string_test() {
@@ -16,7 +22,7 @@ string_test() {
             echo "$i found - passed"
         else
             echo "$i not found - failed"
-            RESULT=1
+            RESULT=$((RESULT+1))
         fi
     done
 }

--- a/tests/cenity/disabled-tik_progress.sh
+++ b/tests/cenity/disabled-tik_progress.sh
@@ -15,8 +15,6 @@ strings=(
   "100%"
   "[cenity][][]"
 )
-cat /tmp/out
-exit
 string_test "${strings[@]}"
 echo
 rm -f /tmp/out

--- a/tests/cenity/manual_progress.sh
+++ b/tests/cenity/manual_progress.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+cenity="../../usr/lib/tik/lib/cenity"
+. $cenity
+
+RESULT=1
+
+z_result="$((
+echo "10" ; sleep 1
+echo "# Updating mail logs" ; sleep 1
+echo "20" ; sleep 1
+echo "# Resetting cron jobs" ; sleep 1
+echo "50" ; sleep 1
+echo "This line will just be ignored" ; sleep 1
+echo "75" ; sleep 1
+echo "# Rebooting system" ; sleep 1
+echo "100" ; sleep 1
+) |
+zenity --progress --title="Update System Logs" \
+  --text="Scanning mail logs..." --percentage=0)" ; z_retval=$?
+
+(
+echo "10" ; sleep 1
+echo "# Updating mail logs" ; sleep 1
+echo "20" ; sleep 1
+echo "# Resetting cron jobs" ; sleep 1
+echo "50" ; sleep 1
+echo "This line will just be ignored" ; sleep 1
+echo "75" ; sleep 1
+echo "# Rebooting system" ; sleep 1
+echo "100" ; sleep 1
+) |
+cenity c_result --progress --title="Update System Logs" \
+  --text="Scanning mail logs..." --percentage=0 ; c_retval=$?
+
+
+echo "[cenity][${c_retval}][${c_result}]"
+echo "[zenity][${z_retval}][${z_result}]"
+
+RESULT=1
+
+z_result="$((
+echo "# Updating mail logs" ; sleep 1
+echo "# Resetting cron jobs" ; sleep 1
+echo "This line will just be ignored" ; sleep 1
+echo "# Rebooting system" ; sleep 1
+) |
+zenity --progress --title="Update System Logs" \
+   --pulsate --auto-close --no-cancel)" ; z_retval=$?
+
+(
+echo "# Updating mail logs" ; sleep 1
+echo "# Resetting cron jobs" ; sleep 1
+echo "This line will just be ignored" ; sleep 1
+echo "# Rebooting system" ; sleep 1
+) |
+cenity c_result --progress --title="Update System Logs" \
+   --pulsate --auto-close --no-cancel ; c_retval=$?
+
+
+echo "[cenity][${c_retval}][${c_result}]"
+echo "[zenity][${z_retval}][${z_result}]"
+
+
+
+if [[ ${c_retval} = ${z_retval} ]] && [[ ${c_result} = ${z_result} ]]; then
+  RESULT=0
+fi
+
+echo "Result: $RESULT"
+

--- a/tests/cenity/run_tests.sh
+++ b/tests/cenity/run_tests.sh
@@ -3,10 +3,30 @@
 PASSED=0
 FAILED=0
 
+mode=diff
+
+for p in "$@"; do
+  case "$p" in
+    --mode*)
+      mode=$(sed 's/^--mode=//' <<< $p)
+      ;;
+    *)
+      echo "Unknown parameter"
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$mode" =~ ^(diff|output|sidebyside)$ ]]; then
+  echo "Unknown mode: $mode"
+  exit 1
+fi
+
 for test in tik_*; do
   RESULT=0
-  echo "Running: ${test}"
-  ./${test} || RESULT=1
+  echo
+  echo "############## Running: ${test} ##############"
+  mode="$mode" ./${test} || RESULT=1
   echo "Test result for ${test}: $RESULT"
   if [ $RESULT == 1 ]; then
     FAILED=$((FAILED+1))

--- a/tests/cenity/tik_entry.sh
+++ b/tests/cenity/tik_entry.sh
@@ -7,6 +7,7 @@ RESULT=0
 #######################################
 asserted_output="$(echo -e '--ENTRY----- This is a ENTRY ----------------
 
+Press CTRL+C to cancel
 [cenity][][Test entry] --entry --text=This is a entry text --title=This is a ENTRY')"
 output="$(c_test --entry --text="This is a entry text" --title="This is a ENTRY" <<< "Test entry" 2>&1)"
 compare "$output" "$asserted_output"

--- a/tests/cenity/tik_error.sh
+++ b/tests/cenity/tik_error.sh
@@ -14,7 +14,8 @@ It can be found on the IGNITION partition on this USB Stick
 
 \033[1mSystem is shutting down\033[0m
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --error --no-wrap --title=Installation Failed --text=Please file a bug report at <tt>TEST URL</tt>\\n\\nPlease include the <tt>tik.log</tt> file\\nIt can be found on the IGNITION partition on this USB Stick\\n\\n<b>System is shutting down</b>')"
 output="$(c_test --error --no-wrap --title="Installation Failed" --text="Please file a bug report at <tt>TEST URL</tt>\n\nPlease include the <tt>tik.log</tt> file\nIt can be found on the IGNITION partition on this USB Stick\n\n<b>System is shutting down</b>" <<< "\n" 2>&1)"
 compare "$output" "$asserted_output"

--- a/tests/cenity/tik_info.sh
+++ b/tests/cenity/tik_info.sh
@@ -11,7 +11,8 @@ asserted_output="$(echo -e '--INFO------  ----------------
 
 Have a nice day!
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --timeout 5 --info --no-wrap --text=<b>Test Succeeded:</b>\\n\\nHave a nice day!')"
 output="$(c_test --timeout 5 --info --no-wrap --text="<b>Test Succeeded:</b>\n\nHave a nice day!" <<< "\n" 2>&1)"
 compare "$output" "$asserted_output"
@@ -24,7 +25,8 @@ TIK_OS_NAME has been installed.
 
 \033[1mSystem is rebooting\033[0m
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --timeout 5 --info --no-wrap --title=Installation Complete! --text=TIK_OS_NAME has been installed.\\n\\n<b>System is rebooting</b>')"
 output="$(c_test --timeout 5 --info --no-wrap --title="Installation Complete!" --text="TIK_OS_NAME has been installed.\n\n<b>System is rebooting</b>" <<< "\n" 2>&1)"
 compare "$output" "$asserted_output"
@@ -51,7 +53,8 @@ You may optionally scan the recovery key off screen:
                              
 For more information please visit \033[1mhttps://aeondesktop.org/encrypt\033[0m
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --width=500 --height=500 --no-wrap --warning --icon=security-high-symbolic --title=Encryption Recovery Key --text=You may optionally scan the recovery key off screen:\\n<span face='\''monospace'\''>                             
                              
     █▀▀▀▀▀█   ▀ █ █▀▀▀▀▀█    
@@ -80,7 +83,8 @@ You will be prompted to set the Passphrase on the next screen
 
 For more information please visit \033[1mhttps://aeondesktop.org/encrypt\033[0m
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --width=500 --height=300 --no-wrap --warning --icon=security-high-symbolic --title=Set Encryption Passphrase --text=This  system is encrypted and will require a Passphrase on every boot\\n\\nYou will be prompted to set the Passphrase on the next screen\\n\\nFor more information please visit <tt>https://aeondesktop.org/encrypt</tt>')"
 output="$(c_test --width=500 --height=300 --no-wrap --warning --icon=security-high-symbolic --title="Set Encryption Passphrase" --text="This ${TIK_OS_NAME} system is encrypted and will require a Passphrase on every boot\n\nYou will be prompted to set the Passphrase on the next screen\n\nFor more information please visit <tt>https://aeondesktop.org/encrypt</tt>" <<< "\n" 2>&1)"
 compare "$output" "$asserted_output"
@@ -97,14 +101,25 @@ We are sorry that you need to reinstall your system
 Thank you so much for your support.
 We hope you enjoy the new look openSUSE Aeon
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --info --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --no-wrap --title=Message from the Aeon Team --text=We'\''d like to thank you for adopting openSUSE Aeon so early in it'\''s development,\\nbefore we fully understood what we were building or how we wanted it to look\\n\\nWe are sorry that you need to reinstall your system\\n\\nThank you so much for your support.\\nWe hope you enjoy the new look openSUSE Aeon')"
 output="$(c_test --info --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic  --no-wrap --title="Message from the Aeon Team" --text="We'd like to thank you for adopting openSUSE Aeon so early in it's development,\nbefore we fully understood what we were building or how we wanted it to look\n\nWe are sorry that you need to reinstall your system\n\nThank you so much for your support.\nWe hope you enjoy the new look openSUSE Aeon" <<< "\n" 2>&1)"
 compare "$output" "$asserted_output"
 
 
-# TODO: handle ok label
-#output=$(c_test --info --ok-label="Install Now" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="<big>Welcome to ${TIK_OS_NAME}</big>\n\nPlease press <b>Install Now</b> to continue")
+#######################################
+asserted_output="$(echo -e '--INFO------  ----------------
+
+\033[1mWelcome to \033[0m
+
+Please press \033[1mInstall Now\033[0m to continue
+
+Press CTRL+C to cancel
+Press any key to Install Now
+[cenity][][] --info --ok-label=Install Now --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title= --text=<big>Welcome to </big>\\n\\nPlease press <b>Install Now</b> to continue')"
+output="$(c_test --info --ok-label="Install Now" --no-wrap --width=300 --height=300 --icon=distributor-logo-Aeon-symbolic --title="" --text="<big>Welcome to ${TIK_OS_NAME}</big>\n\nPlease press <b>Install Now</b> to continue" <<< "\n" 2>&1)"
+compare "$output" "$asserted_output"
 
 tput sgr0
 check_result

--- a/tests/cenity/tik_list.sh
+++ b/tests/cenity/tik_list.sh
@@ -8,6 +8,7 @@ list_items=' virtio-0987654321 20G 3 unknown(2M),vfat(20M),btrfs(4.3G) virtio-te
 #######################################
 asserted_output="$(echo -e '--LIST------ Select A Disk ----------------
 
+Press CTRL+C to cancel
 Select the disk to install the operating system to.
 
 \033[1mMake sure any important documents and files have been backed up.\033[0m
@@ -26,6 +27,7 @@ compare "$output" "$asserted_output"
 #######################################
 asserted_output="$(echo -e '--LIST------ Select A Disk ----------------
 
+Press CTRL+C to cancel
 Select the disk to install the operating system to.
 
 \033[1mMake sure any important documents and files have been backed up.\033[0m
@@ -45,6 +47,7 @@ list_items='tik-osimage-Aeon.20240731.raw.xz 1501130408 tik-osimage-Aeon.test2.r
 #######################################
 asserted_output="$(echo -e '--LIST------ Select A Image ----------------
 
+Press CTRL+C to cancel
 Select the operating system image to install.
 
 Item  Image                             Size
@@ -61,6 +64,7 @@ compare "$output" "$asserted_output"
 #######################################
 asserted_output="$(echo -e '--LIST------ Select A Image ----------------
 
+Press CTRL+C to cancel
 Select the operating system image to install.
 
 Item  Image                             Size

--- a/tests/cenity/tik_password.sh
+++ b/tests/cenity/tik_password.sh
@@ -7,6 +7,7 @@ RESULT=0
 #######################################
 asserted_output="$(echo -e '--PASSWORD-- Set Encryption Passphrase ----------------
 
+Press CTRL+C to cancel
 [cenity][][test] --password --title=Set Encryption Passphrase')"
 output="$(c_test --password --title='Set Encryption Passphrase' <<< "test" 2>&1)"
 compare "$output" "$asserted_output"

--- a/tests/cenity/tik_progress.sh
+++ b/tests/cenity/tik_progress.sh
@@ -15,6 +15,8 @@ strings=(
   "100%"
   "[cenity][][]"
 )
+cat /tmp/out
+exit
 string_test "${strings[@]}"
 echo
 rm -f /tmp/out

--- a/tests/cenity/tik_question.sh
+++ b/tests/cenity/tik_question.sh
@@ -10,6 +10,7 @@ asserted_output="\
 
 Do you really want to quit?
 
+Press CTRL+C to cancel
 1) Yes
 2) No
 #? Selected: 1) yes
@@ -24,6 +25,7 @@ asserted_output="\
 
 Do you really want to quit?
 
+Press CTRL+C to cancel
 1) Yes
 2) No
 #? Selected: 2) No
@@ -39,6 +41,7 @@ asserted_output="\
 
 These users will be restored to the new installation.
 
+Press CTRL+C to cancel
 1) Yes
 2) No
 #? Selected: 1) yes
@@ -53,6 +56,7 @@ asserted_output="\
 
 These users will be restored to the new installation.
 
+Press CTRL+C to cancel
 1) Yes
 2) No
 #? Selected: 2) No

--- a/tests/cenity/tik_warning.sh
+++ b/tests/cenity/tik_warning.sh
@@ -12,7 +12,8 @@ Runnning on battery power detected
 
 It is recommended to connect the system to AC power during the install
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --warning --no-wrap --title=AC Power Recommended --text=Runnning on battery power detected\n\nIt is recommended to connect the system to AC power during the install"
 output=$(c_test --warning --no-wrap --title="AC Power Recommended" --text="Runnning on battery power detected\n\nIt is recommended to connect the system to AC power during the install" <<< "\n" 2>&1)
 compare "$output" "$asserted_output"
@@ -23,7 +24,8 @@ asserted_output="$(echo -e '--WARNING---  -------------security-low--
 
 postamble
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --width=600 --warning --icon=security-low-symbolic --text=postamble')"
 output=$(c_test --width=600 --warning --icon=security-low-symbolic --text="postamble" <<< "\n" 2>&1)
 compare "$output" "$asserted_output"
@@ -38,7 +40,8 @@ Reason: reason
 
 postamble
 
-	Press key to continue
+Press CTRL+C to cancel
+Press any key to continue
 [cenity][][] --width=600 --warning --icon=security-medium-symbolic --text=preamble\\n\\nReason: reason\\n\\npostamble')"
 output=$(c_test --width=600 --warning --icon=security-medium-symbolic --text="preamble\n\nReason: reason\n\npostamble" <<< "\n" 2>&1)
 compare "$output" "$asserted_output"

--- a/usr/lib/tik/lib/cenity
+++ b/usr/lib/tik/lib/cenity
@@ -6,6 +6,8 @@ cenity() {
   text=""
   icon="-"
   function=""
+  oklabel="continue"
+  cancellabel="cancel"
   cancel=true
   autoclose=false
   pulsate=false
@@ -49,6 +51,12 @@ cenity() {
         ;;
       --percentage*)
         percentage=$(sed 's/^--percentage=//' <<< $p)
+        ;;
+      --ok-label*)
+        oklabel=$(sed 's/^--ok-label=//' <<< $p)
+        ;;
+      --cancel-label*)
+        cancellabel=$(sed 's/^--cancel-label=//' <<< $p)
         ;;
       --column*)
         columns+=("$(cut -d '=' -f2 <<< $p)")
@@ -97,9 +105,7 @@ cenity() {
 
   if [ $function = "c_progress" ]; then
     echo -e "--PROGESS--- ${title} -------------${icon}--\n"
-    if $cancel; then
-      echo "Progress (CTRL + C to cancel): "
-    fi
+    c_cancel "$cancellabel"
 
     if [ -p /dev/stdin ]; then
       if $pulsate; then
@@ -107,11 +113,13 @@ cenity() {
       else
         while IFS="" read line; do
           c_progress "${line}"
-          if [[ "$line" == 100 ]] && [ "$autoclose" = true ]; then
-            return 0
-          fi
+          if [[ "$line" == 100 ]]; then 
+            break
+	  fi
         done
       fi
+      exec </dev/tty >/dev/tty
+      c_handle_key "$oklabel"
     fi
   else
     result=""
@@ -165,9 +173,20 @@ c_handle_icon() {
 }
 
 
-c_key() {
-  echo -e "\tPress key to continue"
-  read -n 1 -s -r
+c_cancel() {
+  cancellabel="$1"
+  if $cancel; then
+    echo -e "Press CTRL+C to ${cancellabel}"
+  fi
+}
+
+
+c_handle_key() {
+  oklabel="$1"
+  if ! $autoclose; then
+    echo -e "Press any key to ${oklabel}"
+    read -n 1 -s -r
+  fi
 }
 
 
@@ -212,6 +231,7 @@ c_list() {
   done
 
   echo -e "--LIST------ ${title} -------------${icon}--\n"
+  c_cancel "$cancellabel"
   echo -e "${text}"
 
   output="Item "
@@ -245,6 +265,7 @@ c_question() {
 
   echo -e "--QUESTION-- ${title} -------------${icon}--\n"
   echo -e "${text}\n"
+  c_cancel "$cancellabel"
 
   select yn in "Yes" "No"; do
     case $yn in
@@ -269,6 +290,7 @@ c_entry() {
   local icon=$4
 
   echo -e "--ENTRY----- ${title} -------------${icon}--\n"
+  c_cancel "$cancellabel"
   read -p "${text}: "
   eval $1='$REPLY'
 }
@@ -280,6 +302,7 @@ c_password() {
   local icon=$4
 
   echo -e "--PASSWORD-- ${title} -------------${icon}--\n"
+  c_cancel "$cancellabel"
   read -s -p "${text}: "
   eval $1='$REPLY'
 }
@@ -292,7 +315,8 @@ c_info() {
 
   echo -e "--INFO------ ${title} -------------${icon}--\n"
   echo -e "${text}\n"
-  c_key
+  c_cancel "$cancellabel"
+  c_handle_key "$oklabel"
 }
 
 
@@ -303,7 +327,8 @@ c_warning() {
 
   echo -e "--WARNING--- ${title} -------------${icon}--\n"
   echo -e "${text}\n"
-  c_key
+  c_cancel "$cancellabel"
+  c_handle_key "$oklabel" "$cancellabel"
 }
 
 
@@ -314,5 +339,6 @@ c_error() {
 
   echo -e "--ERROR----- ${title} -------------${icon}--\n"
   echo -e "${text}\n"
-  c_key
+  c_cancel "$cancellabel"
+  c_handle_key "$oklabel" "$cancellabel"
 }


### PR DESCRIPTION
This change:
- Adds handling of ok-label and cancel-label by the cli interface
- Fixes the tests to work with the changed output layout
- Disables the automatic tik_progress test which was unreliable and hackish and failed with the label changes
- Adds a simple manual tik_progress test, that makes comparing progress output with from cenity with zenity easier
- Adds output and diff mode to the cenity test framework, so it's easier to generate all cli interfaces for manual inspection