### PR TITLE
PCR 15 Password Fix

### DIFF
--- a/usr/lib/tik/modules/post/15-encrypt
+++ b/usr/lib/tik/modules/post/15-encrypt
@@ -131,7 +131,7 @@ configure_encryption() {
         # - 3 - Firmware from pluggable hardware. Attaching hardware to your laptop shouldn't hinder booting
     fi
     # Populate ESP
-    prun /usr/bin/chroot ${encrypt_dir}/mnt sdbootutil -vv --esp-path /boot/efi --no-variables install 1>&2
+    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv --esp-path /boot/efi --no-variables install 1>&2
     echo "56" > ${encrypt_pipe}
     echo "# Creating initrd" > ${encrypt_pipe}
     # FIXME: Dracut gets confused by previous installations on occasion with the default config, override the problematic option temporarily

--- a/usr/lib/tik/modules/post/15-encrypt
+++ b/usr/lib/tik/modules/post/15-encrypt
@@ -137,7 +137,7 @@ configure_encryption() {
     # FIXME: Dracut gets confused by previous installations on occasion with the default config, override the problematic option temporarily
     /usr/bin/echo 'hostonly_cmdline="no"' | prun tee ${encrypt_dir}/mnt/etc/dracut.conf.d/99-tik.conf
     # mkinitrd done by add-all-kernels
-    prun /usr/bin/chroot ${encrypt_dir}/mnt sdbootutil -vv --esp-path /boot/efi --no-variables add-all-kernels 1>&2
+    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv --esp-path /boot/efi --no-variables add-all-kernels 1>&2
     # FIXME: Dracut gets confused by previous installations on occasion with the default config, remove override now initrd done
     prun /usr/bin/rm ${encrypt_dir}/mnt/etc/dracut.conf.d/99-tik.conf
     echo "70" > ${encrypt_pipe}
@@ -160,7 +160,7 @@ EOF
         prun /usr/bin/ln -s ${encrypt_dir}/mnt/etc/systemd/system/firstboot-update-predictions.service ${encrypt_dir}/mnt/etc/systemd/system/default.target.wants/firstboot-update-predictions.service
         log "[configure_encryption] Generating Predictions"
         echo "# Generating TPM Predictions" > ${encrypt_pipe}
-        prun /usr/bin/chroot ${encrypt_dir}/mnt sdbootutil -vv update-predictions
+        prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv update-predictions
         echo "73" > ${encrypt_pipe}
         log "[configure_encryption] Default Mode - Enrolling ${cryptpart} to TPM 2.0"
         echo "# Enrolling to TPM" > ${encrypt_pipe}

--- a/usr/lib/tik/modules/post/15-encrypt
+++ b/usr/lib/tik/modules/post/15-encrypt
@@ -131,13 +131,13 @@ configure_encryption() {
         # - 3 - Firmware from pluggable hardware. Attaching hardware to your laptop shouldn't hinder booting
     fi
     # Populate ESP
-    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv --esp-path /boot/efi --no-variables install 1>&2
+    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=$(< ${tik_keyfile}) sdbootutil -vv --esp-path /boot/efi --no-variables install 1>&2
     echo "56" > ${encrypt_pipe}
     echo "# Creating initrd" > ${encrypt_pipe}
     # FIXME: Dracut gets confused by previous installations on occasion with the default config, override the problematic option temporarily
     /usr/bin/echo 'hostonly_cmdline="no"' | prun tee ${encrypt_dir}/mnt/etc/dracut.conf.d/99-tik.conf
     # mkinitrd done by add-all-kernels
-    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv --esp-path /boot/efi --no-variables add-all-kernels 1>&2
+    prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=$(< ${tik_keyfile}) sdbootutil -vv --esp-path /boot/efi --no-variables add-all-kernels 1>&2
     # FIXME: Dracut gets confused by previous installations on occasion with the default config, remove override now initrd done
     prun /usr/bin/rm ${encrypt_dir}/mnt/etc/dracut.conf.d/99-tik.conf
     echo "70" > ${encrypt_pipe}
@@ -160,7 +160,7 @@ EOF
         prun /usr/bin/ln -s ${encrypt_dir}/mnt/etc/systemd/system/firstboot-update-predictions.service ${encrypt_dir}/mnt/etc/systemd/system/default.target.wants/firstboot-update-predictions.service
         log "[configure_encryption] Generating Predictions"
         echo "# Generating TPM Predictions" > ${encrypt_pipe}
-        prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=${tik_keyfile} sdbootutil -vv update-predictions
+        prun /usr/bin/chroot ${encrypt_dir}/mnt KEY=$(< ${tik_keyfile}) sdbootutil -vv update-predictions
         echo "73" > ${encrypt_pipe}
         log "[configure_encryption] Default Mode - Enrolling ${cryptpart} to TPM 2.0"
         echo "# Enrolling to TPM" > ${encrypt_pipe}


### PR DESCRIPTION
Fixes:

https://bugzilla.opensuse.org/attachment.cgi?id=885531
https://bugzilla.opensuse.org/attachment.cgi?id=885547

"KEY=" is should now be usable for providing the key when updating the predictions with PCR15 see:

https://github.com/openSUSE/sdbootutil/issues/306#issuecomment-3269267645

I added "KEY=" for every time predictions are updated for redundancy but it should work fine with only one variable. (the one on line 149)

I've not tested this so it does need testing!

Side question can you reopen:

https://github.com/sysrich/tik/pull/56

I accidentally closed it because I don't know how Github works lol.