### PR TITLE
Rework checkLaptop function

### DIFF
--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -15,7 +15,7 @@ checkLaptop() {
         #Test for respectively Handheld, Notebook, Laptop, and Portable
         chassis=`cat /sys/class/dmi/id/chassis_type`
         #if chassis variable matches 8 9 10 or 11 function continues else it proceeds to test AC power and Battery
-        [[ "$(< /sys/class/dmi/id/chassis_type)" =~ ^(8|9|10|11)$ ]] || return
+        [[ $chassis =~ ^(8|9|10|11)$ ]] || return
           if [[ `systemd-ac-power -v` == "no" ]]; then
             #if we are discharging show AC warning
             log "AC Power disconnected and Battery is not charging"

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -15,10 +15,8 @@ checkLaptop() {
         #Test for respectively Handheld, Notebook, Laptop, and Portable
         chassis=`cat /sys/class/dmi/id/chassis_type`
         #if chassis variable matches 8 9 10 or 11 function continues else it proceeds to test AC power and Battery
-        [[ "$chassis" =~ ^(8|9|10|11)$ ]] || return
-          #Only check for Battery status with upower
-          updevices=`/usr/bin/upower -e|grep -E 'DisplayDevice'`
-          if [[ `/usr/bin/upower -i $updevices|awk '/state:/ {print $2}'` == discharging ]]; then
+        [[ "$(< /sys/class/dmi/id/chassis_type)" =~ ^(8|9|10|11)$ ]] || return
+          if [[ `systemd-ac-power -v` == "no" ]]; then
             #if we are discharging show AC warning
             log "AC Power disconnected and Battery is not charging"
             displayACWarningMsg

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -12,27 +12,17 @@ displayACWarningMsg() {
 }
 
 checkLaptop() {
-        chassis=`cat /sys/class/dmi/id/chassis_type`
         #Test for respectively Handheld, Notebook, Laptop, and Portable
+        chassis=`cat /sys/class/dmi/id/chassis_type`
         #if chassis variable matches 8 9 10 or 11 function continues else it proceeds to test AC power and Battery
-        [[ "$chassis" =~ ^(8|9|10|11)$ ]] || return 
-        #Tested machine is confirmed mobile
-        givePowerRecommendation=false
-        #Only check for AC and Battery power connections with upower
-        updevices=`/usr/bin/upower -e|grep -E 'line_power|BAT'`
-        for pdev in $updevices; do
-            #Get detailed info for each AC and BAT device in upower
-            upinfo=`/usr/bin/upower -i $pdev|grep -E 'online|state'`
-            #Check for discharging state or AC power offline which is equal to no state
-            if [[ "$upinfo" =~ (discharging|no) ]]; then
-                #Give power recommendation only once, so set this to true
-                givePowerRecommendation=true
-            fi
-        done
-        if [ "$givePowerRecommendation" = true ]; then
+        [[ "$chassis" =~ ^(8|9|10|11)$ ]] || return
+          #Only check for Battery status with upower
+          updevices=`/usr/bin/upower -e|grep -E 'DisplayDevice'`
+          if [[ `/usr/bin/upower -i $updevices|awk '/state:/ {print $2}'` == discharging ]]; then
+            #if we are discharging show AC warning
             log "AC Power disconnected and Battery is not charging"
             displayACWarningMsg
-        fi
+          fi
 }
 
 verify_efi() {

--- a/usr/lib/tik/modules/pre/10-welcome
+++ b/usr/lib/tik/modules/pre/10-welcome
@@ -19,7 +19,7 @@ checkLaptop() {
         #Tested machine is confirmed mobile
         givePowerRecommendation=false
         #Only check for AC and Battery power connections with upower
-        updevices=`/usr/bin/upower -e|grep -E 'AC|BAT'`
+        updevices=`/usr/bin/upower -e|grep -E 'line_power|BAT'`
         for pdev in $updevices; do
             #Get detailed info for each AC and BAT device in upower
             upinfo=`/usr/bin/upower -i $pdev|grep -E 'online|state'`


### PR DESCRIPTION
PR opened to fix two bugs.

Bug 1:

`/usr/bin/upower -e|grep -E 'AC|BAT'` on some devices the line_power path doesn't end with AC we can observe that with my device.

```
aeon@localhost:~/Downloads> /usr/bin/upower -e|grep -E 'AC|BAT'
/org/freedesktop/UPower/devices/battery_BAT0
aeon@localhost:~/Downloads> /usr/bin/upower -e|grep -E 'line_power|BAT'
/org/freedesktop/UPower/devices/battery_BAT0
/org/freedesktop/UPower/devices/line_power_ADP1
```

And on some devices there are multiple line_power paths so for example if one path is for a barrel jack adapter and another is for a USB c depending on the one the script selects and the one the user is charging with it might not work properly.

Bug 2: 

Multiple battery device might not be handled well because sometimes their batteries charge one after the other not at the same time so when the script checks if the laptop is charging it might miss it by checking the wrong battery. Of course there is the AC check as back up but if you combine that with bug 1 everything breaks.

Solution:

I dropped checking for line_power and switched upower to find "/org/freedesktop/UPower/devices/DisplayDevice" which should "combine" any potential multi batteries into one.

This is also a guaranteed path so it's safe and in theory we can make the code even shorter by just using the full path instead of finding it.

`if [[ `/usr/bin/upower -i $updevices|awk '/state:/ {print $2}'` == discharging ]]; then`

If the output is anything but discharging then we can assume the user is charging and continue.

This also prevents any issues on laptop without their battery/s because we can just assume they are already on AC power since their device must be powered without a battery somehow.

I also simplified the code a lot while I was try to fix the bugs.